### PR TITLE
Pretend to always have the default session configuration

### DIFF
--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -21,6 +21,10 @@ open class Session: URLSession {
     private var completedInteractions = [Interaction]()
     private var completionBlock: (() -> Void)?
 
+    open override var configuration: URLSessionConfiguration {
+        return .default
+    }
+
     override open var delegate: URLSessionDelegate? {
         return backingSession.delegate
     }


### PR DESCRIPTION
The latest Alamofire access `.configuration` which currently blows up.