### PR TITLE
Refactor cassette locating

### DIFF
--- a/Sources/DVR/Cassette.swift
+++ b/Sources/DVR/Cassette.swift
@@ -4,14 +4,12 @@ struct Cassette {
 
     // MARK: - Properties
 
-    let name: String
     let interactions: [Interaction]
 
 
     // MARK: - Initializers
 
-    init(name: String, interactions: [Interaction]) {
-        self.name = name
+    init(interactions: [Interaction]) {
         self.interactions = interactions
     }
 
@@ -35,16 +33,11 @@ struct Cassette {
 extension Cassette {
     var dictionary: [String: Any] {
         return [
-            "name": name as Any,
             "interactions": interactions.map { $0.dictionary }
         ]
     }
 
     init?(dictionary: [String: Any]) {
-        guard let name = dictionary["name"] as? String else { return nil }
-
-        self.name = name
-
         if let array = dictionary["interactions"] as? [[String: Any]] {
             interactions = array.compactMap { Interaction(dictionary: $0) }
         } else {

--- a/Sources/DVR/Interaction.swift
+++ b/Sources/DVR/Interaction.swift
@@ -7,16 +7,14 @@ struct Interaction {
     let request: URLRequest
     let response: Foundation.URLResponse
     let responseData: Data?
-    let recordedAt: Date
 
 
     // MARK: - Initializers
 
-    init(request: URLRequest, response: Foundation.URLResponse, responseData: Data? = nil, recordedAt: Date = Date()) {
+    init(request: URLRequest, response: Foundation.URLResponse, responseData: Data? = nil) {
         self.request = request
         self.response = response
         self.responseData = responseData
-        self.recordedAt = recordedAt
     }
 
 
@@ -78,7 +76,6 @@ extension Interaction {
     var dictionary: [String: Any] {
         var dictionary: [String: Any] = [
             "request": request.dictionary,
-            "recorded_at": recordedAt.timeIntervalSince1970
         ]
 
         var responseDictionary = self.response.dictionary
@@ -99,12 +96,10 @@ extension Interaction {
 
     init?(dictionary: [String: Any]) {
         guard let request = dictionary["request"] as? [String: Any],
-            let response = dictionary["response"] as? [String: Any],
-            let recordedAt = dictionary["recorded_at"] as? TimeInterval else { return nil }
+            let response = dictionary["response"] as? [String: Any] else { return nil }
 
         self.request = NSMutableURLRequest(dictionary: request) as URLRequest
         self.response = HTTPURLResponse(dictionary: response)
-        self.recordedAt = Date(timeIntervalSince1970: recordedAt)
         self.responseData = Interaction.dencodeBody(response["body"], headers: response["headers"] as? [String: String])
     }
 }

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -215,7 +215,7 @@ open class Session: URLSession {
             string = string.appending("\n") as NSString
 
             if let data = string.data(using: String.Encoding.utf8.rawValue) {
-                try? data.write(to: cassetteURL, options: [.atomic])
+                try data.write(to: cassetteURL, options: [.atomic])
                 return
             }
 


### PR DESCRIPTION
Try to make recording more pleasant by writing recorded cassettes directly into the source tree and removing the requirement that cassettes are added to the test bundle.
Also remove `recordedAt`.